### PR TITLE
Simplify custom gate save proof of concept

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,15 +10,18 @@ from logic_circuits.pygame_representation.utils import (
     truthtable_print
 )
 from logic_circuits.pygame_representation.gates_graphical import (
-    GatePass_graphical, SysIN_graphical
+    GateGENERIC_graphical,
+    GatePass_graphical,
+    SysIN_graphical,
 )
 from logic_circuits.pygame_representation.wires import Wire
 from logic_circuits.pygame_representation.button import Button
-from logic_circuits.pygame_representation.library import library_items
+from logic_circuits.pygame_representation.library import (
+    library_items,
+    add_library_item,
+)
 from logic_circuits.pygame_representation.pygame_cfg import *
 from logic_circuits.gates.gates import make_combined_gate_class
-
-
 def main():
     # -------------------
     # INIT
@@ -33,6 +36,15 @@ def main():
     # -------------------
     # UI ELEMENTS
     # -------------------
+    save_button = Button(
+        rect=(W - 280, 20, 120, 40),
+        text="Save",
+        font=fonts.FONT,
+        bg_color=(70, 70, 200),
+        fg_color=(255, 255, 255),
+        hover_color=(90, 90, 220),
+    )
+
     play_button = Button(
         rect=(W - 140, 20, 120, 40),
         text="Play",
@@ -65,6 +77,7 @@ def main():
     block_drag_offset = Vector2(0, 0)
 
     truth_lines = None
+    custom_gate_count = 0
     running = True
 
     # -------------------
@@ -197,6 +210,12 @@ def main():
             # -------------------
             # PLAY BUTTON
             # -------------------
+            if save_button.handle_event(event):
+                if len(connections) > 0:
+                    custom_gate_count += 1
+                    base_name = f"Custom{custom_gate_count}"
+                    add_library_item(base_name.upper(), GateGENERIC_graphical)
+
             if play_button.handle_event(event):
                 if len(connections) > 0:
                     new_gate = make_combined_gate_class(
@@ -280,6 +299,7 @@ def main():
             )
             screen.blit(hint, (12, 10))
 
+        save_button.draw(screen)
         play_button.draw(screen)
         if truth_lines:
             x, y = LIBRARY_WIDTH + 20, H - 150   # position bottom right

--- a/src/logic_circuits/pygame_representation/custom_gate.py
+++ b/src/logic_circuits/pygame_representation/custom_gate.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Dict, List, Tuple, Type
+
+import numpy as np
+
+from logic_circuits.gates.gates import GateAND, GateNOT, GatePASS, GateBase, SysIN
+from .gates_graphical import (
+    GateAND_graphical,
+    GateNOT_graphical,
+    GatePass_graphical,
+    Gate_graphical,
+    SysIN_graphical,
+)
+
+
+@dataclass(frozen=True)
+class GateSpec:
+    """Blueprint for instantiating a logical gate when recreating composites."""
+
+    factory: Callable[[], GateBase]
+
+
+@dataclass(frozen=True)
+class Blueprint:
+    gate_specs: Dict[str, GateSpec]
+    connections: List[Tuple[str, str, int, int]]
+    input_gate_id: str
+    end_gate_ids: List[str]
+    num_in: int
+    num_out: int
+
+
+def _factory_for_gate(gate: GateBase) -> Callable[[], GateBase]:
+    """Return a callable that produces a fresh logical gate equivalent to *gate*."""
+
+    if isinstance(gate, SysIN_graphical):
+        return partial(SysIN, name=gate.name, num_in=gate.num_in, num_out=gate.num_out)
+    if isinstance(gate, GatePass_graphical):
+        return partial(GatePASS, name=gate.name, num_in=gate.num_in, num_out=gate.num_out)
+    if isinstance(gate, GateAND_graphical):
+        return partial(GateAND, name=gate.name)
+    if isinstance(gate, GateNOT_graphical):
+        return partial(GateNOT, name=gate.name)
+    if hasattr(gate, "logical_cls"):
+        logical_cls: Type[GateBase] = getattr(gate, "logical_cls")
+        return partial(logical_cls, instance_name=gate.name)
+    raise TypeError(f"Unsupported gate type for custom save: {type(gate)!r}")
+
+
+def build_blueprint(
+    sysin: SysIN_graphical,
+    sysout: GatePass_graphical,
+    connections: List[Tuple[GateBase, GateBase, int, int]],
+) -> Blueprint:
+    """Construct a reusable blueprint for the current workspace configuration."""
+
+    involved: List[GateBase] = []
+    seen = set()
+    for from_gate, to_gate, *_ in connections:
+        if from_gate not in seen:
+            involved.append(from_gate)
+            seen.add(from_gate)
+        if to_gate not in seen:
+            involved.append(to_gate)
+            seen.add(to_gate)
+
+    for anchor in (sysin, sysout):
+        if anchor not in seen:
+            involved.append(anchor)
+            seen.add(anchor)
+
+    gate_ids = {gate: f"g{idx}" for idx, gate in enumerate(involved)}
+    gate_specs = {gid: GateSpec(factory=_factory_for_gate(gate)) for gate, gid in gate_ids.items()}
+
+    connection_specs = [
+        (gate_ids[from_gate], gate_ids[to_gate], from_port, to_port)
+        for from_gate, to_gate, from_port, to_port in connections
+    ]
+
+    return Blueprint(
+        gate_specs=gate_specs,
+        connections=connection_specs,
+        input_gate_id=gate_ids[sysin],
+        end_gate_ids=[gate_ids[sysout]],
+        num_in=sysin.num_out,
+        num_out=sysout.num_out,
+    )
+
+
+def make_custom_gate_class(name: str, blueprint: Blueprint) -> Type[GateBase]:
+    """Create a new logical gate class driven by *blueprint*."""
+
+    class _CustomGate(GateBase):
+        def __init__(self, instance_name: str | None = None):
+            super().__init__(blueprint.num_in, blueprint.num_out, name=name)
+            self.name = instance_name or name
+
+            # Instantiate a fresh network for this gate instance.
+            self._gate_instances: Dict[str, GateBase] = {
+                gid: spec.factory() for gid, spec in blueprint.gate_specs.items()
+            }
+
+            for from_id, to_id, from_port, to_port in blueprint.connections:
+                to_gate = self._gate_instances[to_id]
+                from_gate = self._gate_instances[from_id]
+                to_gate.wire_up(from_gate, to_gate, from_port, to_port)
+
+            self._input_gate = self._gate_instances[blueprint.input_gate_id]
+            self._end_gates = [self._gate_instances[idx] for idx in blueprint.end_gate_ids]
+
+        def _compute(self) -> np.ndarray:
+            inputs = self._collect_inputs()
+            ports = list(range(self._input_gate.num_out))
+            self._input_gate.set_state(ports, list(bool(v) for v in inputs))
+
+            end_state: List[bool] = []
+            for gate in self._end_gates:
+                gate._recompute()
+                end_state.extend(bool(v) for v in gate.state)
+            return np.array(end_state, dtype=bool)
+
+    _CustomGate.__name__ = name
+    return _CustomGate
+
+
+def make_custom_gate_graphical_class(
+    name: str,
+    logical_class: Type[GateBase],
+    num_in: int,
+    num_out: int,
+) -> Type[Gate_graphical]:
+    """Return a pygame-ready wrapper around the logical custom gate class."""
+
+    class _CustomGateGraphical(Gate_graphical):
+        logical_cls = logical_class
+
+        def __init__(
+            self,
+            name: str,
+            x: int,
+            y: int,
+            w: int = 220,
+            h: int = 140,
+            num_in: int = num_in,
+            num_out: int = num_out,
+        ) -> None:
+            logical_gate = logical_class(instance_name=name)
+            super().__init__(logical_gate, name, x, y, w, h, num_in=num_in, num_out=num_out)
+
+    _CustomGateGraphical.__name__ = f"{name}Graphical"
+    return _CustomGateGraphical

--- a/src/logic_circuits/pygame_representation/gates_graphical.py
+++ b/src/logic_circuits/pygame_representation/gates_graphical.py
@@ -101,6 +101,52 @@ class GateAND_graphical(GateAND):
 
 
 
+class GateGENERIC_graphical(GatePASS):
+    PAD = 14
+    CORNER = 12
+
+    def __init__(self, name, x, y, w=220, h=140, num_in=2, num_out=1):
+        super().__init__(name=name, num_in=num_in, num_out=num_out)
+
+        self.num_in = num_in
+        self.num_out = num_out
+        self._x = x
+        self._y = y
+        self._w, self._h = w, h
+        self.rect = pygame.Rect(self._x, self._y, self._w, self._h)
+        self.inputs = []
+        self.outputs = []
+        self._make_ports()
+
+    def _make_ports(self):
+        left_x  = 0 + self.PAD
+        right_x = self.rect.w - self.PAD
+        ys_in   = [self.rect.h * (idx+1)/(self.num_in+1) for idx in range(self.num_in)]
+        ys_out   = [self.rect.h * (idx+1)/(self.num_out+1) for idx in range(self.num_out)]
+
+        self.inputs  = [Port_graphical(self, 'in',  (left_x,  y), idx) for idx, y in enumerate(ys_in)]
+        self.outputs = [Port_graphical(self, 'out', (right_x, y), idx) for idx, y in enumerate(ys_out)]
+
+    def hover(self, mouse):
+        return self.rect.collidepoint(mouse)
+
+    def move_by(self, dx, dy):
+        self.rect.move_ip(dx, dy)
+
+    def draw(self, surf):
+        pygame.draw.rect(surf, BLOCK_FILL, self.rect, border_radius=self.CORNER)
+        pygame.draw.rect(surf, BLOCK_OUTL, self.rect, 2, border_radius=self.CORNER)
+        if fonts.FONT:
+            label = fonts.FONT.render(self.name, True, TEXT)
+            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery-35))
+            surf.blit(label, label_rect)
+
+        mx, my = pygame.mouse.get_pos()
+        for p in self.inputs + self.outputs:
+            p.draw(surf, p.hover((mx, my)))
+
+
+
 class GateNOT_graphical(GateNOT):
     PAD = 14
     CORNER = 12

--- a/src/logic_circuits/pygame_representation/library.py
+++ b/src/logic_circuits/pygame_representation/library.py
@@ -3,6 +3,7 @@ from . import fonts
 from .gates_graphical import GateAND_graphical, GateNOT_graphical
 from .pygame_cfg import *
 
+
 class LibraryItem:
     def __init__(self, rect, text, gate_class):
         self.rect = pygame.Rect(rect)
@@ -13,15 +14,26 @@ class LibraryItem:
         pygame.draw.rect(surface, (60, 60, 60), self.rect)
         pygame.draw.rect(surface, (200, 200, 200), self.rect, 2)
         label = fonts.FONT.render(self.text, True, (255, 255, 255))
-        surface.blit(label, (self.rect.x+10, self.rect.y+10))
+        surface.blit(label, (self.rect.x + 10, self.rect.y + 10))
 
     def hover(self, pos):
         return self.rect.collidepoint(pos)
 
-library_items = [
-    LibraryItem((20, 40, 100, 40), "AND", GateAND_graphical),
-    LibraryItem((20, 40+50*1, 100, 40), "NOT", GateNOT_graphical),
-]
+
+def _item_rect(index: int) -> pygame.Rect:
+    return pygame.Rect(20, 40 + 50 * index, 100, 40)
+
+
+def add_library_item(text, gate_class):
+    item = LibraryItem(_item_rect(len(library_items)), text, gate_class)
+    library_items.append(item)
+    return item
+
+
+library_items = []
+add_library_item("AND", GateAND_graphical)
+add_library_item("NOT", GateNOT_graphical)
+
 
 dragging_library_item = None
 ghost_gate = None


### PR DESCRIPTION
## Summary
- add a GateGENERIC_graphical placeholder that mirrors the existing gate widgets
- wire the Save button to append a generic gate entry to the library list when a circuit is present

## Testing
- python -m compileall src main.py

------
https://chatgpt.com/codex/tasks/task_e_68d6501cceec83298f7124d6f6f63e48