### PR TITLE
Refactor graphical pass-through gates to share logic

### DIFF
--- a/src/logic_circuits/pygame_representation/gates_graphical.py
+++ b/src/logic_circuits/pygame_representation/gates_graphical.py
@@ -1,9 +1,8 @@
 import pygame
+
 from .ports import Port_graphical
 from .colors import BLOCK_FILL, BLOCK_OUTL, TEXT
 from . import fonts
-from pygame.math import Vector2
-from logic_circuits.gates.gates import GateBase
 from logic_circuits.gates.gates import GateAND, GateNOT, GatePASS, SysIN
 
 
@@ -25,34 +24,31 @@ class GateAND_graphical(GateAND):
         self._make_ports()
 
     def _make_ports(self):
-        left_x  = 0 + self.PAD
+        left_x = 0 + self.PAD
         right_x = self.rect.w - self.PAD
-        ys_in   = [self.rect.h * (idx+1)/(self.num_in+1) for idx in range(self.num_in)]
-        ys_out   = [self.rect.h * (idx+1)/(self.num_out+1) for idx in range(self.num_out)]
-        
-        self.inputs  = [Port_graphical(self, 'in',  (left_x,  y), idx) for idx, y in enumerate(ys_in)]
+        ys_in = [self.rect.h * (idx + 1) / (self.num_in + 1) for idx in range(self.num_in)]
+        ys_out = [self.rect.h * (idx + 1) / (self.num_out + 1) for idx in range(self.num_out)]
+
+        self.inputs = [Port_graphical(self, 'in', (left_x, y), idx) for idx, y in enumerate(ys_in)]
         self.outputs = [Port_graphical(self, 'out', (right_x, y), idx) for idx, y in enumerate(ys_out)]
 
-    
     def hover(self, mouse):
         return self.rect.collidepoint(mouse)
-    
 
     def move_by(self, dx, dy):
         self.rect.move_ip(dx, dy)
 
-    def draw(self, surf):   
+    def draw(self, surf):
         pygame.draw.rect(surf, BLOCK_FILL, self.rect, border_radius=self.CORNER)
         pygame.draw.rect(surf, BLOCK_OUTL, self.rect, 2, border_radius=self.CORNER)
         if fonts.FONT:
             label = fonts.FONT.render(self.name, True, TEXT)
-            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery-35))
-            surf.blit(label, label_rect) 
-            
+            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery - 35))
+            surf.blit(label, label_rect)
+
         mx, my = pygame.mouse.get_pos()
         for p in self.inputs + self.outputs:
             p.draw(surf, p.hover((mx, my)))
-
 
 
 class GateNOT_graphical(GateNOT):
@@ -73,106 +69,26 @@ class GateNOT_graphical(GateNOT):
         self._make_ports()
 
     def _make_ports(self):
-        left_x  = 0 + self.PAD
+        left_x = 0 + self.PAD
         right_x = self.rect.w - self.PAD
-        ys_in   = [self.rect.h * (idx+1)/(self.num_in+1) for idx in range(self.num_in)]
-        ys_out   = [self.rect.h * (idx+1)/(self.num_out+1) for idx in range(self.num_out)]
-        
-        self.inputs  = [Port_graphical(self, 'in',  (left_x,  y), idx) for idx, y in enumerate(ys_in)]
+        ys_in = [self.rect.h * (idx + 1) / (self.num_in + 1) for idx in range(self.num_in)]
+        ys_out = [self.rect.h * (idx + 1) / (self.num_out + 1) for idx in range(self.num_out)]
+
+        self.inputs = [Port_graphical(self, 'in', (left_x, y), idx) for idx, y in enumerate(ys_in)]
         self.outputs = [Port_graphical(self, 'out', (right_x, y), idx) for idx, y in enumerate(ys_out)]
 
-    
     def hover(self, mouse):
         return self.rect.collidepoint(mouse)
 
     def move_by(self, dx, dy):
         self.rect.move_ip(dx, dy)
 
-    def draw(self, surf):   
+    def draw(self, surf):
         pygame.draw.rect(surf, BLOCK_FILL, self.rect, border_radius=self.CORNER)
         pygame.draw.rect(surf, BLOCK_OUTL, self.rect, 2, border_radius=self.CORNER)
         if fonts.FONT:
             label = fonts.FONT.render(self.name, True, TEXT)
-            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery-30))
-            surf.blit(label, label_rect) 
-
-        mx, my = pygame.mouse.get_pos()
-        for p in self.inputs + self.outputs:
-            p.draw(surf, p.hover((mx, my)))
-
-
-
-
-class GatePass_graphical(GatePASS):
-    PAD = 14
-    CORNER = 12
-
-    def __init__(self, name, x, y, w=220, h=140, num_in=1, num_out=1):
-        super().__init__(name=name, num_in=num_in, num_out=num_out)
-
-        self.num_in = num_in
-        self.num_out = num_out
-        self._x = x
-        self._y = y
-        self._w, self._h = w, h
-        self.rect = pygame.Rect(self._x, self._y, self._w, self._h)
-        self.plus = pygame.Rect(self._x+self._w/2, self._y, self._w/10, self._h/10)
-        self.minus = pygame.Rect(self._x+self._w/2, self._y+self._h-self._h/10, self._w/10, self._h/10)
-
-        self.inputs = []
-        self.outputs = []
-        self._make_ports()
-
-    def _make_ports(self):
-        left_x  = 0 + self.PAD
-        right_x = self.rect.w - self.PAD
-        ys_in   = [self.rect.h * (idx+1)/(self.num_in+1) for idx in range(self.num_in)]
-        ys_out   = [self.rect.h * (idx+1)/(self.num_out+1) for idx in range(self.num_out)]
-        
-        self.inputs  = [Port_graphical(self, 'in',  (left_x,  y), idx) for idx, y in enumerate(ys_in)]
-        self.outputs = [Port_graphical(self, 'out', (right_x, y), idx) for idx, y in enumerate(ys_out)]
-
-    def increase_ports(self):
-        self.__init__(self.name, self._x, self._y, self._w, self._h, self.num_in+1, self.num_in+1)
-    
-    def decrease_ports(self):
-        if self.num_in>1:
-            self.__init__(self.name, self._x, self._y, self._w, self._h, self.num_in-1, self.num_in-1)
-    
-    def hover(self, mouse):
-        return self.rect.collidepoint(mouse)
-    
-    def hover_plus(self, mouse):
-        return self.plus.collidepoint(mouse)
-    
-    def hover_minus(self, mouse):
-        return self.minus.collidepoint(mouse)
-    def move_by(self, dx, dy):
-        self.rect.move_ip(dx, dy)
-
-    def draw(self, surf):   
-        pygame.draw.rect(surf, BLOCK_FILL, self.rect, border_radius=self.CORNER)
-        pygame.draw.rect(surf, BLOCK_OUTL, self.rect, 2, border_radius=self.CORNER)
-
-        # --- center plus & minus horizontally ---
-        self.plus.centerx = self.rect.centerx
-        self.minus.centerx = self.rect.centerx
-
-        pygame.draw.rect(surf, (0, 255, 0), self.plus)
-        pygame.draw.rect(surf, (255, 0, 0), self.minus)
-
-        if fonts.FONT:
-            plus_label = fonts.FONT.render("+", True, (0, 0, 0))
-            plus_rect = plus_label.get_rect(center=self.plus.center)
-            surf.blit(plus_label, plus_rect)
-
-            minus_label = fonts.FONT.render("-", True, (0, 0, 0))
-            minus_rect = minus_label.get_rect(center=self.minus.center)
-            surf.blit(minus_label, minus_rect)
-
-        if fonts.FONT:
-            label = fonts.FONT.render(self.name, True, TEXT)
-            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery))
+            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery - 30))
             surf.blit(label, label_rect)
 
         mx, my = pygame.mouse.get_pos()
@@ -180,78 +96,118 @@ class GatePass_graphical(GatePASS):
             p.draw(surf, p.hover((mx, my)))
 
 
+class _AdjustableGraphicalGate:
+    """Shared graphical behaviour for gates with configurable I/O counts."""
 
-
-class SysIN_graphical(SysIN):
     PAD = 14
     CORNER = 12
+    _CONTROL_RATIO = 10
 
-    def __init__(self, name, x, y, w=220, h=140, num_in=1, num_out=1):
-        super().__init__(name, num_in, num_out)
+    def _init_graphics(self, x, y, w, h, num_in, num_out):
+        """Initialise geometry and recreate ports based on the gate layout."""
+        self.rect = pygame.Rect(x, y, w, h)
 
-        self.num_in = num_in
-        self.num_out = num_out
-        self._x = x
-        self._y = y
-        self._w, self._h = w, h
-        self.rect = pygame.Rect(self._x, self._y, self._w, self._h)
-        self.plus = pygame.Rect(self._x+self._w/2, self._y, self._w/10, self._h/10)
-        self.minus = pygame.Rect(self._x+self._w/2, self._y+self._h-self._h/10, self._w/10, self._h/10)
+        control_w = max(1, int(round(w / self._CONTROL_RATIO)))
+        control_h = max(1, int(round(h / self._CONTROL_RATIO)))
+
+        self.plus = pygame.Rect(0, 0, control_w, control_h)
+        self.minus = pygame.Rect(0, 0, control_w, control_h)
+        self.plus.midtop = (self.rect.centerx, self.rect.top)
+        self.minus.midbottom = (self.rect.centerx, self.rect.bottom)
 
         self.inputs = []
         self.outputs = []
-        self._make_ports()
+        self._set_port_counts(num_in, num_out)
 
-    def _make_ports(self):
-        left_x  = 0 + self.PAD
+    def _set_port_counts(self, num_in, num_out):
+        self.num_in = num_in
+        self.num_out = num_out
+
+        left_x = self.PAD
         right_x = self.rect.w - self.PAD
-        ys_in   = [self.rect.h * (idx+1)/(self.num_in+1) for idx in range(self.num_in)]
-        ys_out   = [self.rect.h * (idx+1)/(self.num_out+1) for idx in range(self.num_out)]
-        
-        self.inputs  = [Port_graphical(self, 'in',  (left_x,  y), idx) for idx, y in enumerate(ys_in)]
-        self.outputs = [Port_graphical(self, 'out', (right_x, y), idx) for idx, y in enumerate(ys_out)]
+
+        ys_in = [self.rect.h * (idx + 1) / (self.num_in + 1) for idx in range(self.num_in)]
+        ys_out = [self.rect.h * (idx + 1) / (self.num_out + 1) for idx in range(self.num_out)]
+
+        self.inputs = [
+            Port_graphical(self, 'in', (left_x, y), idx)
+            for idx, y in enumerate(ys_in)
+        ]
+        self.outputs = [
+            Port_graphical(self, 'out', (right_x, y), idx)
+            for idx, y in enumerate(ys_out)
+        ]
+
+    def _resize(self, num_in, num_out):
+        x, y = self.rect.topleft
+        w, h = self.rect.size
+
+        self._reset_logic(num_in, num_out)
+        self._init_graphics(x, y, w, h, num_in, num_out)
 
     def increase_ports(self):
-        self.__init__(self.name, self._x, self._y, self._w, self._h, self.num_in+1, self.num_in+1)
-    
+        self._resize(self.num_in + 1, self.num_in + 1)
+
     def decrease_ports(self):
-        if self.num_in>1:
-            self.__init__(self.name, self._x, self._y, self._w, self._h, self.num_in-1, self.num_in-1)
-    
+        if self.num_in > 1:
+            self._resize(self.num_in - 1, self.num_in - 1)
+
     def hover(self, mouse):
         return self.rect.collidepoint(mouse)
-    
+
     def hover_plus(self, mouse):
         return self.plus.collidepoint(mouse)
-    
+
     def hover_minus(self, mouse):
         return self.minus.collidepoint(mouse)
-    
-    def draw(self, surf):   
+
+    def move_by(self, dx, dy):
+        self.rect.move_ip(dx, dy)
+        self.plus.move_ip(dx, dy)
+        self.minus.move_ip(dx, dy)
+
+    def draw(self, surf):
         pygame.draw.rect(surf, BLOCK_FILL, self.rect, border_radius=self.CORNER)
         pygame.draw.rect(surf, BLOCK_OUTL, self.rect, 2, border_radius=self.CORNER)
 
-        # --- center plus & minus horizontally ---
-        self.plus.centerx = self.rect.centerx
-        self.minus.centerx = self.rect.centerx
+        # keep the controls anchored to the top/bottom centre of the gate
+        self.plus.midtop = (self.rect.centerx, self.rect.top)
+        self.minus.midbottom = (self.rect.centerx, self.rect.bottom)
 
         pygame.draw.rect(surf, (0, 255, 0), self.plus)
         pygame.draw.rect(surf, (255, 0, 0), self.minus)
 
         if fonts.FONT:
-            plus_label = fonts.FONT.render("+", True, (0, 0, 0))
+            plus_label = fonts.FONT.render('+', True, (0, 0, 0))
             plus_rect = plus_label.get_rect(center=self.plus.center)
             surf.blit(plus_label, plus_rect)
 
-            minus_label = fonts.FONT.render("-", True, (0, 0, 0))
+            minus_label = fonts.FONT.render('-', True, (0, 0, 0))
             minus_rect = minus_label.get_rect(center=self.minus.center)
             surf.blit(minus_label, minus_rect)
 
-        if fonts.FONT:
             label = fonts.FONT.render(self.name, True, TEXT)
-            label_rect = label.get_rect(center=(self.rect.centerx, self.rect.centery))
+            label_rect = label.get_rect(center=self.rect.center)
             surf.blit(label, label_rect)
 
         mx, my = pygame.mouse.get_pos()
         for p in self.inputs + self.outputs:
             p.draw(surf, p.hover((mx, my)))
+
+
+class GatePass_graphical(_AdjustableGraphicalGate, GatePASS):
+    def __init__(self, name, x, y, w=220, h=140, num_in=1, num_out=1):
+        GatePASS.__init__(self, name=name, num_in=num_in, num_out=num_out)
+        self._init_graphics(x, y, w, h, num_in, num_out)
+
+    def _reset_logic(self, num_in, num_out):
+        GatePASS.__init__(self, name=self.name, num_in=num_in, num_out=num_out)
+
+
+class SysIN_graphical(_AdjustableGraphicalGate, SysIN):
+    def __init__(self, name, x, y, w=220, h=140, num_in=1, num_out=1):
+        SysIN.__init__(self, name, num_in, num_out)
+        self._init_graphics(x, y, w, h, num_in, num_out)
+
+    def _reset_logic(self, num_in, num_out):
+        SysIN.__init__(self, self.name, num_in, num_out)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_pygame():
+    import pygame
+
+    pygame.display.init()
+    pygame.font.init()
+    yield
+    pygame.font.quit()
+    pygame.display.quit()

--- a/tests/pygame_representation/test_gates_graphical.py
+++ b/tests/pygame_representation/test_gates_graphical.py
@@ -1,0 +1,152 @@
+import math
+
+import numpy as np
+import pygame
+import pytest
+
+from logic_circuits.pygame_representation.gates_graphical import (
+    GateAND_graphical,
+    GateNOT_graphical,
+    GatePass_graphical,
+    SysIN_graphical,
+)
+from logic_circuits.pygame_representation.ports import Port_graphical
+
+
+@pytest.fixture
+def surface():
+    return pygame.Surface((600, 400))
+
+
+def assert_ports_aligned(ports, gate_rect, pad, expected_count):
+    assert len(ports) == expected_count
+    for port in ports:
+        assert isinstance(port, Port_graphical)
+        # ports are anchored relative to the gate rectangle
+        assert gate_rect.collidepoint(tuple(port.screen_pos()))
+        if port.kind == "in":
+            assert math.isclose(port.screen_pos().x, gate_rect.left + pad, abs_tol=1e-6)
+        else:
+            assert math.isclose(port.screen_pos().x, gate_rect.right - pad, abs_tol=1e-6)
+
+
+def test_pass_graphical_initial_layout():
+    gate = GatePass_graphical("pass", x=20, y=25, w=180, h=120, num_in=3, num_out=3)
+
+    assert gate.rect.topleft == (20, 25)
+    assert gate.rect.size == (180, 120)
+    assert gate.num_in == 3 and gate.num_out == 3
+
+    assert_ports_aligned(gate.inputs, gate.rect, gate.PAD, 3)
+    assert_ports_aligned(gate.outputs, gate.rect, gate.PAD, 3)
+
+    # control rectangles are anchored to the top/bottom centre
+    assert gate.plus.midtop == (gate.rect.centerx, gate.rect.top)
+    assert gate.minus.midbottom == (gate.rect.centerx, gate.rect.bottom)
+
+    # logical state mirrors the graphical configuration
+    assert gate.brigde.shape == (gate.num_in,)
+    assert len(gate.out_ports) == gate.num_out
+
+
+def test_increase_and_decrease_ports_updates_geometry_and_logic():
+    gate = GatePass_graphical("pass", x=0, y=0, w=200, h=150, num_in=1, num_out=1)
+
+    gate.increase_ports()
+    assert gate.num_in == gate.num_out == 2
+    assert_ports_aligned(gate.inputs, gate.rect, gate.PAD, 2)
+    assert_ports_aligned(gate.outputs, gate.rect, gate.PAD, 2)
+    assert gate.brigde.shape == (2,)
+    assert len(gate.out_ports) == 2
+
+    gate.increase_ports()
+    assert gate.num_in == gate.num_out == 3
+    assert gate.brigde.shape == (3,)
+
+    # decrease down to one and ensure it does not go below
+    gate.decrease_ports()
+    assert gate.num_in == gate.num_out == 2
+    gate.decrease_ports()
+    assert gate.num_in == gate.num_out == 1
+    gate.decrease_ports()
+    assert gate.num_in == gate.num_out == 1
+
+
+def test_move_by_keeps_controls_and_ports_synced():
+    gate = GatePass_graphical("pass", x=10, y=10, w=160, h=90, num_in=2, num_out=2)
+    original_inputs = [p.offset.copy() for p in gate.inputs]
+    original_outputs = [p.offset.copy() for p in gate.outputs]
+
+    gate.move_by(15, 20)
+
+    assert gate.rect.topleft == (25, 30)
+    assert gate.plus.midtop == (gate.rect.centerx, gate.rect.top)
+    assert gate.minus.midbottom == (gate.rect.centerx, gate.rect.bottom)
+
+    # port offsets are relative and should be unchanged
+    for port, offset in zip(gate.inputs, original_inputs):
+        assert port.offset == offset
+    for port, offset in zip(gate.outputs, original_outputs):
+        assert port.offset == offset
+
+
+def test_draw_realigns_controls(surface):
+    gate = GatePass_graphical("pass", x=0, y=0, w=210, h=110, num_in=2, num_out=2)
+
+    # perturb the control rectangles intentionally
+    gate.plus.topleft = (5, 5)
+    gate.minus.topleft = (5, 5)
+
+    gate.draw(surface)
+
+    assert gate.plus.midtop == (gate.rect.centerx, gate.rect.top)
+    assert gate.minus.midbottom == (gate.rect.centerx, gate.rect.bottom)
+
+
+def test_hover_detection_for_controls_and_body():
+    gate = GatePass_graphical("pass", x=40, y=60, w=120, h=100, num_in=1, num_out=1)
+
+    assert gate.hover(gate.rect.center)
+    assert gate.hover_plus(gate.plus.center)
+    assert gate.hover_minus(gate.minus.center)
+
+    assert not gate.hover((gate.rect.right + 5, gate.rect.bottom + 5))
+
+
+def test_sysin_resize_preserves_base_layer_and_state_semantics():
+    gate = SysIN_graphical("sys", x=0, y=0, w=200, h=120, num_in=2, num_out=2)
+
+    assert gate.base_layer is True
+    gate.set_state([0, 1], [True, False])
+    np.testing.assert_array_equal(gate.state, np.array([True, False], dtype=bool))
+
+    gate.increase_ports()  # -> 3 inputs/outputs
+    assert gate.base_layer is True
+    assert gate.num_in == gate.num_out == 3
+    assert gate.brigde.shape == (3,)
+    assert len(gate.out_ports) == 3
+
+    gate.set_state(2, True)
+    np.testing.assert_array_equal(gate.state, np.array([False, False, True], dtype=bool))
+
+    gate.decrease_ports()  # -> 2
+    gate.decrease_ports()  # -> 1
+    gate.set_state(0, False)
+    np.testing.assert_array_equal(gate.state, np.array([False], dtype=bool))
+
+
+def test_gate_and_and_not_graphical_create_ports_and_hover(surface):
+    and_gate = GateAND_graphical("and", x=5, y=5, w=180, h=120, num_in=2, num_out=1)
+    not_gate = GateNOT_graphical("not", x=10, y=15, w=150, h=90, num_in=1, num_out=1)
+
+    assert_ports_aligned(and_gate.inputs, and_gate.rect, and_gate.PAD, 2)
+    assert_ports_aligned(and_gate.outputs, and_gate.rect, and_gate.PAD, 1)
+    assert_ports_aligned(not_gate.inputs, not_gate.rect, not_gate.PAD, 1)
+    assert_ports_aligned(not_gate.outputs, not_gate.rect, not_gate.PAD, 1)
+
+    # draw should not raise and should render ports in hover/no-hover states
+    and_gate.draw(surface)
+    not_gate.draw(surface)
+
+    assert and_gate.hover(and_gate.rect.center)
+    assert not not_gate.hover((not_gate.rect.right + 10, not_gate.rect.bottom + 10))


### PR DESCRIPTION
## Summary
- introduce a shared `_AdjustableGraphicalGate` mixin to centralise the resizable gate UI logic
- update `GatePass_graphical` and `SysIN_graphical` to use the mixin, removing the duplicated setup/draw code
- ensure the plus/minus controls stay aligned with the gate rectangle for hover and movement interactions

## Testing
- python -m compileall src/logic_circuits/pygame_representation/gates_graphical.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6a22d4d88329bae149583ab7ba9d